### PR TITLE
WIP: improve EDDB download and update times

### DIFF
--- a/modules/eddb/factions.js
+++ b/modules/eddb/factions.js
@@ -131,12 +131,24 @@ function Factions() {
             })
     };
 
+    const bulkUpdateCallback = function(err, result){
+          if (err) {
+             console.log(`Errors: ${err.result.getWriteErrorCount()}, example: ${err.message}`);
+             result = err.result;
+          }
+          if (result) {
+             console.log(`${result.insertedCount} inserted, ${result.matchedCount} matched, ${result.modifiedCount} modified, ${result.upsertedCount} upserted`);
+          }
+    }
+
     this.downloadUpdate = function () {
-        let recordsUpdated = 0;
+        let recordsFound = 0;
+        let operations = [];
         let stream = utilities.downloadUpdate('https://eddb.io/archive/v6/factions.json', 'json');
         stream
             .on('start', response => {
                 console.log(`EDDB faction dump started with status code ${response.statusCode}`);
+                console.time('faction')
                 this.emit('started', {
                     response: response,
                     insertion: "started",
@@ -145,32 +157,46 @@ function Factions() {
             })
             .on('data', async json => {
                 stream.pause();
-                try {
-                    await factionsModel.findOneAndUpdate(
-                        {
-                            id: json.id,
-                            updated_at: { $ne: json.updated_at }
-                        },
-                        json,
-                        {
-                            upsert: true,
-                            runValidators: true
-                        });
-                    recordsUpdated++;
-                } catch (err) {
+                json.updated_at = json.updated_at * 1000;
+                json.name_lower = json.name.toLowerCase();
+                operations.push({
+                                  updateOne: {
+                                    filter: {
+                                      id: json.id,
+//                                      updated_at: { $ne: json.updated_at }
+                                    },
+                                    update: { $set: json },
+                                    upsert: true
+                                  }
+                                });
+                recordsFound++;
+                if (operations.length % 1000 === 0 ) {
+                  try {
+                       await factionsModel.bulkWrite(
+                         operations,
+                         { ordered: false },
+                         bulkUpdateCallback
+                       );
+                  } catch (err) {
                     this.emit('error', err);
-                } finally {
-                    stream.resume();
+                  }
                 }
+                operations = [];
+                stream.resume();
             })
             .on('end', () => {
-                console.log(`${recordsUpdated} records updated`);
-                this.emit('done', recordsUpdated);
+                factionsModel.bulkWrite(
+                  operations,
+                  { ordered: false },
+                  bulkUpdateCallback
+                );
+                console.timeEnd('faction');
+                console.log(`${recordsFound} records processed.`);
+                this.emit('done', recordsFound);
             })
             .on('error', err => {
                 this.emit('error', err);
             })
     }
 }
-
 inherits(Factions, eventEmmiter);

--- a/modules/eddb/populated_systems.js
+++ b/modules/eddb/populated_systems.js
@@ -133,12 +133,24 @@ function PopulatedSystems() {
             })
     };
 
+    const bulkUpdateCallback = function(err, result){
+          if (err) {
+             console.log(`Errors: ${err.result.getWriteErrorCount()}, example: ${err.message}`);
+             result = err.result;
+          }
+          if (result) {
+             console.log(`${result.insertedCount} inserted, ${result.matchedCount} matched, ${result.modifiedCount} modified, ${result.upsertedCount} upserted`);
+          }
+    }
+
     this.downloadUpdate = function () {
-        let recordsUpdated = 0;
+        let recordsFound = 0;
+        let operations = [];
         let stream = utilities.downloadUpdate('https://eddb.io/archive/v6/systems_populated.json', 'json');
         stream
             .on('start', response => {
                 console.log(`EDDB populated system dump started with status code ${response.statusCode}`);
+                console.time('populatedSystems')
                 this.emit('started', {
                     response: response,
                     insertion: "started",
@@ -148,27 +160,39 @@ function PopulatedSystems() {
             .on('data', async json => {
                 stream.pause();
                 json = modify(json);
-                try {
-                    await populatedSystemsModel.findOneAndUpdate(
-                        {
-                            id: json.id,
-                            updated_at: { $ne: json.updated_at }
-                        },
-                        json,
-                        {
-                            upsert: true,
-                            runValidators: true
-                        });
-                    recordsUpdated++;
-                } catch (err) {
+                json.updated_at = json.updated_at * 1000;
+                operations.push({
+                                  updateOne: {
+                                    filter: {
+                                      id: json.id,
+//                                      updated_at: { $ne: json.updated_at }
+                                    },
+                                    update: { $set: json },
+                                    upsert: true
+                                  }
+                                });
+                recordsFound++;
+                if (operations.length % 1000 === 0 ) {
+                  try {
+                       await populatedSystemsModel.bulkWrite(
+                         operations,
+                         { ordered: false },
+                         bulkUpdateCallback
+                       );
+                  } catch (err) {
                     this.emit('error', err);
-                } finally {
-                    stream.resume();
+                  }
                 }
+                operations = [];
+                stream.resume();
             })
             .on('end', () => {
-                console.log(`${recordsUpdated} records updated`);
-                this.emit('done', recordsUpdated);
+                populatedSystemsModel.bulkWrite(
+                  operations,
+                  { ordered: false },
+                  bulkUpdateCallback
+                );
+                console.timeEnd('populatedSystems');
             })
             .on('error', err => {
                 this.emit('error', err);

--- a/modules/eddb/stations.js
+++ b/modules/eddb/stations.js
@@ -133,12 +133,24 @@ function Stations() {
             })
     }
 
+    const bulkUpdateCallback = function(err, result){
+          if (err) {
+             console.log(`Errors: ${err.result.getWriteErrorCount()}, example: ${err.message}`);
+             result = err.result;
+          }
+          if (result) {
+             console.log(`${result.insertedCount} inserted, ${result.matchedCount} matched, ${result.modifiedCount} modified, ${result.upsertedCount} upserted`);
+          }
+    }
+
     this.downloadUpdate = function () {
-        let recordsUpdated = 0;
+        let recordsFound = 0;
+        let operations = [];
         let stream = utilities.downloadUpdate('https://eddb.io/archive/v6/stations.json', 'json');
         stream
             .on('start', response => {
                 console.log(`EDDB station dump started with status code ${response.statusCode}`);
+                console.time('stations')
                 this.emit('started', {
                     response: response,
                     insertion: "started",
@@ -148,27 +160,41 @@ function Stations() {
             .on('data', async json => {
                 stream.pause();
                 json = modify(json);
-                try {
-                    await stationsModel.findOneAndUpdate(
-                        {
-                            id: json.id,
-                            updated_at: { $ne: json.updated_at }
-                        },
-                        json,
-                        {
-                            upsert: true,
-                            runValidators: true
-                        });
-                    recordsUpdated++;
-                } catch (err) {
+                json.updated_at = json.updated_at * 1000;
+                operations.push({
+                                  updateOne: {
+                                    filter: {
+                                      id: json.id,
+//                                      updated_at: { $ne: json.updated_at }
+                                    },
+                                    update: { $set: json },
+                                    upsert: true
+                                  }
+                                });
+                recordsFound++;
+                if (operations.length % 1000 === 0 ) {
+                  try {
+                       await stationsModel.bulkWrite(
+                         operations,
+                         { ordered: false },
+                         bulkUpdateCallback
+                       );
+                  } catch (err) {
                     this.emit('error', err);
-                } finally {
-                    stream.resume();
+                  }
                 }
+                operations = [];
+                stream.resume();
             })
             .on('end', () => {
-                console.log(`${recordsUpdated} records updated`);
-                this.emit('done', recordsUpdated);
+                stationsModel.bulkWrite(
+                  operations,
+                  { ordered: false },
+                  bulkUpdateCallback
+                );
+                console.timeEnd('stations');
+                console.log(`${recordsFound} records processed.`);
+                this.emit('done', recordsFound);
             })
             .on('error', err => {
                 this.emit('error', err);

--- a/modules/eddb/systems.js
+++ b/modules/eddb/systems.js
@@ -131,12 +131,24 @@ function Systems() {
             })
     }
 
+    const bulkUpdateCallback = function(err, result){
+          if (err) {
+             console.log(`Errors: ${err.result.getWriteErrorCount()}, example: ${err.message}`);
+             result = err.result;
+          }
+          if (result) {
+             console.log(`${result.insertedCount} inserted, ${result.matchedCount} matched, ${result.modifiedCount} modified, ${result.upsertedCount} upserted`);
+          }
+    }
+
     this.downloadUpdate = function () {
-        let recordsUpdated = 0;
+        let recordsFound = 0;
+        let operations = [];
         let stream = utilities.downloadUpdate('https://eddb.io/archive/v6/systems.csv', 'csv');
         stream
             .on('start', response => {
                 console.log(`EDDB system dump started with status code ${response.statusCode}`);
+                console.time('systems')
                 this.emit('started', {
                     response: response,
                     insertion: "started",
@@ -145,27 +157,41 @@ function Systems() {
             })
             .on('data', async json => {
                 stream.pause();
-                try {
-                    await systemsModel.findOneAndUpdate(
-                        {
-                            id: json.id,
-                            updated_at: { $ne: json.updated_at }
-                        },
-                        json,
-                        {
-                            upsert: true,
-                            runValidators: true
-                        });
-                    recordsUpdated++;
-                } catch (err) {
+                json.updated_at = json.updated_at * 1000;
+                operations.push({
+                                  updateOne: {
+                                    filter: {
+                                      id: json.id,
+//                                      updated_at: { $ne: json.updated_at }
+                                    },
+                                    update: { $set: json },
+                                    upsert: true
+                                  }
+                                });
+                recordsFound++;
+                if (operations.length % 10000 === 0 ) {
+                  try {
+                       await systemsModel.bulkWrite(
+                         operations,
+                         { ordered: false },
+                         bulkUpdateCallback
+                       );
+                  } catch (err) {
                     this.emit('error', err);
-                } finally {
-                    stream.resume();
+                  }
                 }
+                operations = [];
+                stream.resume();
             })
             .on('end', () => {
-                console.log(`${recordsUpdated} records updated`);
-                this.emit('done', recordsUpdated);
+                systemsModel.bulkWrite(
+                  operations,
+                  { ordered: false },
+                  bulkUpdateCallback
+                );
+                console.timeEnd('faction');
+                console.log(`${recordsFound} records processed.`);
+                this.emit('done', recordsFound);
             })
             .on('error', err => {
                 this.emit('error', err);


### PR DESCRIPTION
Switches to bulk Mongo updates. On my 2CPU/2GB test VM, factions download and update goes from 90s to 7s. However, systems update is still unable to complete, and the others take about 10 minutes each.

TODO: bulkWrite does not invoke middleware. Check on the other middleware in the models and copy them.